### PR TITLE
Fixed route regex

### DIFF
--- a/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
+++ b/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
@@ -22,7 +22,7 @@ class PrometheusFilter @Inject()(implicit
 ) extends Filter {
   private final val ServerErrorClass = "5xx"
 
-  private final val RouteRegex = "^[/a-zA-Z0-9$_\\-]+$".r
+  private final val RouteRegex = "^/[^<]*".r
 
   private val httpHistogramBuckets = {
     val buckets = for (p <- Vector[Double](0.0001, 0.001, 0.01, 0.1, 1, 10);


### PR DESCRIPTION
Previous regex was not catering for possibly encoded characters.

The new one will require a route to start with a `/` and will match everything until the `<` sign that is part of the play regex to match routes internally