### PR TITLE
Removed broken regex and replaced with a replace all

### DIFF
--- a/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
+++ b/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
@@ -22,8 +22,6 @@ class PrometheusFilter @Inject()(implicit
 ) extends Filter {
   private final val ServerErrorClass = "5xx"
 
-  private final val RouteRegex = "^/[^<]*".r
-
   private val httpHistogramBuckets = {
     val buckets = for (p <- Vector[Double](0.0001, 0.001, 0.01, 0.1, 1, 10);
                        s <- Vector(1, 2, 5)) yield (p * s)
@@ -68,8 +66,7 @@ class PrometheusFilter @Inject()(implicit
     for {
       method        <- requestHeader.tags.get("ROUTE_VERB")
       routePattern  <- requestHeader.tags.get("ROUTE_PATTERN")
-      routeTemplate <- RouteRegex findFirstIn routePattern
-      route         =  routeTemplate.replaceAll("\\$", ":")
+      route         =  routePattern.replaceAll("<.*>", "").replaceAll("\\$", ":")
     } yield RouteDetails(method, route)
   }
 


### PR DESCRIPTION
The regex demonstrated of not working well when the a url parameter was in the middle of the path.

Eg.:

```
/resource/:resource_id/sub_path
```

The central part `:resource_id` would look in the templated route like `$resource_id<[^/]+>` and the first `<` would stop the old regex from capturing anything after the `resource_id` section.

The new solution, bit less elegant, is much more effective. It grabs and strips all the `<..>` blocks.
