### PR TITLE
Escape backslash, line feed and double quotes appropriately.

### DIFF
--- a/client/shared/src/main/boilerplate/CounterN.scala.template
+++ b/client/shared/src/main/boilerplate/CounterN.scala.template
@@ -10,6 +10,8 @@ final case class Counter1 private[client] (name: MetricName, help: String, label
 
   override final val metricType = MetricType.Counter
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   def labelValues([#labelValue1: String#]): LabelledCounter =
     new LabelledCounter(name, labels, adders(Tuple1([#labelValue1#])))
 

--- a/client/shared/src/main/boilerplate/GaugeN.scala.template
+++ b/client/shared/src/main/boilerplate/GaugeN.scala.template
@@ -10,6 +10,8 @@ final case class Gauge1 private[client] (name: MetricName, help: String, labels:
 
   override final val metricType = MetricType.Gauge
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   def labelValues([#labelValue1: String#]): LabelledGauge =
     new LabelledGauge(name, labels, adders(Tuple1([#labelValue1#])), initialValue)
 

--- a/client/shared/src/main/boilerplate/HistogramN.scala.template
+++ b/client/shared/src/main/boilerplate/HistogramN.scala.template
@@ -10,6 +10,8 @@ final case class Histogram1 private[client] (name: MetricName, help: String, lab
 
   override final val metricType = MetricType.Histogram
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   def labelValues([#labelValue1: String#]): LabelledHistogram =
     new LabelledHistogram(name, labels, adders(Tuple1([#labelValue1#])))
 

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/DefaultRegistry.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/DefaultRegistry.scala
@@ -15,7 +15,7 @@ class DefaultRegistry extends Registry {
 
   override def collect(): Iterator[RegistryMetrics] = {
     collectors.toIterator.map { c =>
-      RegistryMetrics(c.name, c.help, c.metricType, c.collect())
+      RegistryMetrics(c.name, c.help, c.escapedHelp, c.metricType, c.collect())
     }
   }
 }

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/counter/Counter0.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/counter/Counter0.scala
@@ -16,6 +16,8 @@ final case class Counter0 private[client] (name: MetricName, help: String)
     with MetricFamily {
   override val metricType = MetricType.Counter
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   override def collect(): List[Metric] =
     CounterMetric(List.empty, adder.sum) :: Nil
 }

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/gauge/Gauge0.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/gauge/Gauge0.scala
@@ -17,6 +17,8 @@ final case class Gauge0 private[client] (name: MetricName,
     with MetricFamily {
   override val metricType = MetricType.Gauge
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   override def collect(): List[Metric] =
     synchronized {
       GaugeMetric(List.empty, adder.sum) :: Nil

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/histogram/Histogram0.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/histogram/Histogram0.scala
@@ -20,6 +20,8 @@ final case class Histogram0 private[client] (name: MetricName,
     with MetricFamily {
   override val metricType = MetricType.Histogram
 
+  override final val escapedHelp = help.replace("\\", "\\\\").replace("\n", "\\n")
+
   override def collect(): List[HistogramMetric] = {
     List(
       HistogramMetric(List.empty,

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/jmx.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/jmx.scala
@@ -18,6 +18,7 @@ object jmx {
     override def name: MetricName = metric"jvm_gc_stats"
 
     override def help: String = "JVM Garbage Collector Statistics"
+    override def escapedHelp: String = help
 
     override def metricType = MetricType.Gauge
 
@@ -38,6 +39,7 @@ object jmx {
     override def name: MetricName = metric"jvm_memory_usage"
 
     override def help: String = "JVM Memory Usage"
+    override def escapedHelp: String = help
 
     override def metricType = MetricType.Gauge
 
@@ -66,6 +68,7 @@ object jmx {
     override def name: MetricName = metric"jvm_classloader"
 
     override def help: String = "JVM Classloader statistics"
+    override def escapedHelp: String = help
 
     override def metricType = MetricType.Gauge
 
@@ -85,6 +88,7 @@ object jmx {
     override def name: MetricName = metric"jvm_start_time"
 
     override def help: String = "JVM Start Time"
+    override def escapedHelp: String = help
 
     override def metricType = MetricType.Gauge
 
@@ -97,6 +101,7 @@ object jmx {
     override def name: MetricName = metric"jvm_threads"
 
     override def help: String = "JVM Thread Information"
+    override def escapedHelp: String = help
 
     override def metricType: MetricType = MetricType.Gauge
 

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/Metric.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/Metric.scala
@@ -7,7 +7,10 @@ sealed trait Metric {
 }
 
 case class Bucket(cumulativeCount: Long, upperBound: Double)
-case class LabelPair(name: LabelName, value: String)
+case class LabelPair(name: LabelName, value: String) {
+  final private[registry] val escapedValue: String =
+    value.replace("\\", "\\\\").replace("\n", "\\n").replace("\"", "\\\"")
+}
 
 case class GaugeMetric(labels: List[LabelPair], value: Double)   extends Metric
 case class CounterMetric(labels: List[LabelPair], value: Double) extends Metric

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/MetricFamily.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/MetricFamily.scala
@@ -11,6 +11,8 @@ trait MetricFamily {
   def help: String
   def metricType: MetricType
 
+  private[client] def escapedHelp: String
+
   def register(implicit registry: Registry): this.type = {
     registry.register(this)
     this

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/RegistryMetrics.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/RegistryMetrics.scala
@@ -4,5 +4,6 @@ import org.lyranthe.prometheus.client.{MetricName, MetricType}
 
 case class RegistryMetrics(name: MetricName,
                            help: String,
+                           escapedHelp: String,
                            metricType: MetricType,
                            metrics: List[Metric])

--- a/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/TextFormat.scala
+++ b/client/shared/src/main/scala/org/lyranthe/prometheus/client/registry/TextFormat.scala
@@ -21,18 +21,18 @@ object TextFormat extends RegistryFormat {
   def output(values: => Iterator[RegistryMetrics]): Array[Byte] = {
     val outputStream = new ByteArrayOutputStream(4096)
 
-    def labelsToString(labels: List[LabelPair]) = {
-      if (labels.isEmpty)
+    def labelsToString(labelPairs: List[LabelPair]) = {
+      if (labelPairs.isEmpty)
         ""
       else
-        labels.map {
-          case LabelPair(label, metric) => s"""${label.name}="$metric""""
+        labelPairs.map { pair =>
+          s"""${pair.name.name}="${pair.escapedValue}""""
         }.mkString("{", ",", "}")
     }
 
     values.foreach { metric =>
       val sb = new StringBuilder
-      sb.append(s"# HELP ${metric.name.name} ${metric.help}\n")
+      sb.append(s"# HELP ${metric.name.name} ${metric.escapedHelp}\n")
       sb.append(s"# TYPE ${metric.name.name} ${metric.metricType.toString}\n")
       metric.metrics foreach { rm =>
         rm match {

--- a/site/src/main/tut/guide.md
+++ b/site/src/main/tut/guide.md
@@ -121,12 +121,12 @@ implicit val defaultRegistry = DefaultRegistry()
 implicit val histogramBuckets = HistogramBuckets(1, 2, 5, 10, 20, 50, 100)
 
 val activeRequests = Gauge(metric"active_requests", "Active requests").labels().register
-val numErrors = Counter(metric"num_errors", "Total errors").labels().register
-val requestLatency = Histogram(metric"request_latency", "Request latency").labels(label"path").register
+val numErrors = Counter(metric"total_errors", "Total errors").labels().register
+val requestLatency = Histogram(metric"db_request_duration_seconds", "Request latency\nfrom database").labels(label"sql").register
 
 activeRequests.set(50)
 numErrors.inc
-requestLatency.labelValues("/home").observe(17)
+requestLatency.labelValues("select \nname, age\nfrom\nusers").observe(17)
 implicitly[Registry].outputText
 ```
 
@@ -212,3 +212,4 @@ jmx.register
 
 println(implicitly[Registry].outputText)
 ```
+


### PR DESCRIPTION
In the text output format, some characters have to be escaped specially.

```
metric_name [
  "{" label_name "=" `"` label_value `"` { "," label_name "=" `"` label_value `"` } [ "," ] "}"
] value [ timestamp ]
metric_name and label_name have the usual Prometheus expression language restrictions. label_value can be any sequence of UTF-8 characters, but the backslash, the double-quote, and the line-feed characters have to be escaped as \\, \", and \n, respectively.
```

```
HELP lines may contain any sequence of UTF-8 characters (after the metric name), but the backslash and the line-feed characters have to be escaped as \\ and \n, respectively.
```