### PR TITLE
Fix matching regex in Play plugin

### DIFF
--- a/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
+++ b/yax/play/src/main/scala/org/lyranthe/prometheus/client/integration/play/filters/PrometheusFilter.scala
@@ -66,7 +66,7 @@ class PrometheusFilter @Inject()(implicit
     for {
       method        <- requestHeader.tags.get("ROUTE_VERB")
       routePattern  <- requestHeader.tags.get("ROUTE_PATTERN")
-      route         =  routePattern.replaceAll("<.*>", "").replaceAll("\\$", ":")
+      route         =  routePattern.replaceAll("<.*?>", "").replaceAll("\\$", ":")
     } yield RouteDetails(method, route)
   }
 


### PR DESCRIPTION
The regex `<.*>` has eager/greedy matching - it will match as
many characters as possible. This means that if there are multiple
bound variables in a path, this will match all the characters
between them, removing it from the resulting path label.

This commit changes the regex to use a "reluctant" quantifier.