### PR TITLE
Use a singleton Registry

### DIFF
--- a/guide.md
+++ b/guide.md
@@ -259,7 +259,7 @@ import com.google.inject.AbstractModule
 class Module extends AbstractModule {
 
   override def configure() = {
-    bind(classOf[Registry]).to(classOf[DefaultRegistry])
+    bind(classOf[Registry]).to(classOf[DefaultRegistry]).asEagerSingleton();
   }
   
 }


### PR DESCRIPTION
By default, a different instance of DefaultRegistry will be created for each injection (typically in the Play Filters, and into a Controller for /metrics), but both will use a different Registry instances. Declaring the binding as a singleton fixes the issue.