### PR TITLE
bump dependency and sbt versions to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,13 @@
-enablePlugins(ScalaJSPlugin, CrossPerProjectPlugin)
+import scala.sys.process._
+
+enablePlugins(ScalaJSPlugin)
 
 organization in Global := "org.lyranthe.prometheus"
 
 val scala211 = "2.11.12"
-val scala212 = "2.12.4"
+val scala212 = "2.12.8"
 
-version in ThisBuild := "git describe --tags --dirty --always".!!.stripPrefix(
-  "v").trim
+version in ThisBuild := "git describe --tags --dirty --always".!!.stripPrefix("v").trim
 scalacOptions in (Compile, doc) in ThisBuild ++= Seq("-groups",
                                                      "-implicits",
                                                      "-implicits-show-all",
@@ -96,7 +97,7 @@ val cats =
     .settings(
       scalaVersion := scala211,
       crossScalaVersions := Seq(scala211, scala212),
-      libraryDependencies += "org.typelevel" %%% "cats-effect" % "0.8"
+      libraryDependencies += "org.typelevel" %%% "cats-effect" % "1.2.0"
     )
     .dependsOn(client)
 
@@ -110,7 +111,7 @@ val benchmark =
     .settings(
       scalaVersion := scala211,
       crossScalaVersions := Seq(scala211),
-      libraryDependencies += "io.prometheus" % "simpleclient" % "0.2.0"
+      libraryDependencies += "io.prometheus" % "simpleclient" % "0.6.0"
     )
     .dependsOn(clientJVM)
 
@@ -166,7 +167,8 @@ val akkaHttp =
       scalaVersion := scala211,
       crossScalaVersions := Seq(scala211, scala212),
       libraryDependencies ++= Seq(
-        "com.typesafe.akka" %% "akka-http" % "10.0.11" % "provided" withSources ()
+        "com.typesafe.akka" %% "akka-http" % "10.1.7" % "provided" withSources (),
+        "com.typesafe.akka" %% "akka-stream" % "2.5.20" % "provided" withSources ()
       )
     )
     .dependsOn(clientJVM)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,12 +2,12 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh"         % "0.3.3")
 addSbtPlugin("io.spray"           % "sbt-boilerplate" % "0.6.1")
-addSbtPlugin("org.tpolecat"       % "tut-plugin"      % "0.5.6")
+addSbtPlugin("org.tpolecat"       % "tut-plugin"      % "0.6.10")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt-coursier" % "1.15")
 
-addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "1.1.0")
+addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "2.0.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 addSbtPlugin("com.jsuereth"   % "sbt-pgp"      % "1.1.0")
@@ -26,5 +26,3 @@ addSbtPlugin("io.get-coursier"  % "sbt-coursier" % "1.0.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git"      % "0.9.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
-
-addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/project/yax.scala
+++ b/project/yax.scala
@@ -98,6 +98,6 @@ object yax {
       Seq(sourceGenerators += foo(root, "main", flags: _*).taskValue)) ++
       inConfig(Test)(
         Seq(sourceGenerators += foo(root, "test", flags: _*).taskValue)) ++
-      Seq(watchSources := watchSources.value ++ closure(root))
+      Seq(watchSources ++= closure(root).get)
 
 }


### PR DESCRIPTION
This bumps to the latest versions of prometheus simpleclient, akka-http and sbt. The sbt version bump required a few additional bumps of plugins and minor changes to the build.